### PR TITLE
Update Vercel Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Follow along with [the official tutorial](https://docs.magic.link/integrations/t
 
 ## Deploy your own
 
-Deploy the example using [Vercel Now](https://vercel.com/docs/now-cli#commands/overview/basic-usage):
+Deploy the example with [Vercel](https://vercel.com/docs):
 
-[![Deploy with Vercel Now](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fmagiclabs%2Fexample-nextjs-faunadb-todomvc&env=NEXT_PUBLIC_MAGIC_PUBLISHABLE_KEY,MAGIC_SECRET_KEY,FAUNADB_SECRET_KEY,ENCRYPTION_SECRET)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https%3A%2F%2Fgithub.com%2Fmagiclabs%2Fexample-nextjs-faunadb-todomvc&env=NEXT_PUBLIC_MAGIC_PUBLISHABLE_KEY,MAGIC_SECRET_KEY,FAUNADB_SECRET_KEY,ENCRYPTION_SECRET)
 
 ## Configuration
 


### PR DESCRIPTION
This PR updates "Vercel Now" to "Vercel" - both the company and product/platform name are now the same.

In addition to this, the link is changed to be the docs entry point as this is preferable to CLI deployment.